### PR TITLE
Refactor entry scripts into functions with config struct

### DIFF
--- a/main.m
+++ b/main.m
@@ -1,0 +1,13 @@
+% main.m
+%
+% Simple wrapper script to run the key project phases using default
+% configuration settings.
+%
+% Users can modify the `cfg` structure below to customize paths or
+% parameters and then run this file for a one-click execution.
+
+cfg = struct();
+
+run_phase2_model_selection_comparative(cfg);
+run_phase3_final_evaluation(cfg);
+run_phase4_feature_interpretation(cfg);

--- a/run_phase2_model_selection_comparative.m
+++ b/run_phase2_model_selection_comparative.m
@@ -1,4 +1,5 @@
-% run_phase2_model_selection_comparative.m
+function run_phase2_model_selection_comparative(cfg)
+%RUN_PHASE2_MODEL_SELECTION_COMPARATIVE
 %
 % Main script for Phase 2: Model and Feature Selection Pipelines.
 % Implements nested cross-validation to find the best combination of
@@ -10,10 +11,19 @@
 
 %% 0. Initialization
 fprintf('PHASE 2: Model Selection & Outlier Strategy Comparison - %s\n', string(datetime('now')));
-clear; clc; close all;
+
+if nargin < 1
+    cfg = struct();
+end
+if ~isfield(cfg, 'projectRoot')
+    cfg.projectRoot = pwd;
+end
+if ~isfield(cfg, 'outlierStrategiesToCompare')
+    cfg.outlierStrategiesToCompare = {'OR', 'AND'};
+end
 
 % --- Define Paths ---
-projectRoot = pwd; 
+projectRoot = cfg.projectRoot;
 if ~exist(fullfile(projectRoot, 'src'), 'dir') || ~exist(fullfile(projectRoot, 'data'), 'dir')
     error('Project structure not found. Run from project root. Current: %s', projectRoot);
 end
@@ -36,7 +46,7 @@ for i=1:length(dirToEnsure), if ~isfolder(dirToEnsure{i}), mkdir(dirToEnsure{i})
 dateStrForFilenames = string(datetime('now','Format','yyyyMMdd'));
 
 % --- Define Outlier Strategies to Compare & Result Storage ---
-outlierStrategiesToCompare = {'OR', 'AND'};
+outlierStrategiesToCompare = cfg.outlierStrategiesToCompare;
 overallComparisonResults = struct(); 
 
 %% --- MAIN LOOP FOR OUTLIER STRATEGIES ---
@@ -476,3 +486,4 @@ end
 
 % This should be one of the last outputs of your script.
 fprintf('\nPHASE 2 Processing & Outlier Strategy Comparison Complete (with OverallComparisonData save): %s\n', string(datetime('now')));
+end

--- a/run_phase3_final_evaluation.m
+++ b/run_phase3_final_evaluation.m
@@ -1,4 +1,5 @@
-% run_phase3_final_evaluation.m
+function run_phase3_final_evaluation(cfg)
+%RUN_PHASE3_FINAL_EVALUATION
 %
 % Script for Phase 3: Final Model Training & Unbiased Evaluation.
 % 1. Trains the best pipeline from Phase 2 (MRMRLDA) on the entire training set.
@@ -8,11 +9,17 @@
 
 %% 0. Initialization
 % =========================================================================
-clear; clc; close all;
 fprintf('PHASE 3: Final Model Training & Unbiased Evaluation - %s\n', string(datetime('now')));
 
+if nargin < 1
+    cfg = struct();
+end
+if ~isfield(cfg, 'projectRoot')
+    cfg.projectRoot = pwd;
+end
+
 % --- Define Paths (Simplified) ---
-projectRoot = pwd; % Assumes current working directory IS the project root.
+projectRoot = cfg.projectRoot; % Assumes current working directory is project root unless overridden
 if ~exist(fullfile(projectRoot, 'src'), 'dir') || ~exist(fullfile(projectRoot, 'data'), 'dir')
     error(['Project structure not found. Please ensure MATLAB''s "Current Folder" is set to your ' ...
            'main project root directory before running. Current directory is: %s'], projectRoot);
@@ -889,3 +896,4 @@ function fh_roc_det = plotRocAndDetCurves(trueLabels, scores, positiveClassIdent
     end
 end
 % --- END: Definition of plotRocAndDetCurves ---
+end

--- a/run_phase3_final_evaluation_OR_strategy.m
+++ b/run_phase3_final_evaluation_OR_strategy.m
@@ -1,4 +1,5 @@
-% run_phase3_final_evaluation_OR_strategy.m % RENAMED for clarity
+function run_phase3_final_evaluation_OR_strategy(cfg)
+%RUN_PHASE3_FINAL_EVALUATION_OR_STRATEGY
 %
 % Script for Phase 3: Final Model Training & Unbiased Evaluation.
 % Focuses on the "T2 OR Q" outlier strategy.
@@ -12,11 +13,17 @@
 
 %% 0. Initialization
 % =========================================================================
-clear; clc; close all;
 fprintf('PHASE 3: Final Model Training & Unbiased Evaluation (T2 OR Q Strategy) - %s\n', string(datetime('now')));
 
+if nargin < 1
+    cfg = struct();
+end
+if ~isfield(cfg, 'projectRoot')
+    cfg.projectRoot = pwd;
+end
+
 % --- Define Paths ---
-projectRoot = pwd; 
+projectRoot = cfg.projectRoot;
 if ~exist(fullfile(projectRoot, 'src'), 'dir') || ~exist(fullfile(projectRoot, 'data'), 'dir')
     error(['Project structure not found. Please ensure MATLAB''s "Current Folder" is set to your ' ...
            'main project root directory before running. Current directory is: %s'], projectRoot);
@@ -422,3 +429,4 @@ close(figProbDist_OR);
 % Violin plots can also be generated here if desired, similar to the probe probability plot
 
 fprintf('\nPHASE 3 Processing Complete (Focused on OR Strategy): %s\n', string(datetime('now')));
+end

--- a/run_phase4_feature_interpretation.m
+++ b/run_phase4_feature_interpretation.m
@@ -1,4 +1,5 @@
-% run_phase4_feature_interpretation.m
+function run_phase4_feature_interpretation(cfg)
+%RUN_PHASE4_FEATURE_INTERPRETATION
 %
 % Script for Phase 4: Final Interpretation & Reporting.
 % Focuses on identifying key discriminative wavenumbers from the final
@@ -8,11 +9,17 @@
 
 %% 0. Initialization
 % =========================================================================
-clear; clc; close all;
 fprintf('PHASE 4: Feature Interpretation - %s\n', string(datetime('now')));
 
+if nargin < 1
+    cfg = struct();
+end
+if ~isfield(cfg, 'projectRoot')
+    cfg.projectRoot = pwd;
+end
+
 % --- Define Paths (Simplified) ---
-projectRoot = pwd; % Assumes current working directory IS the project root.
+projectRoot = cfg.projectRoot; % Assumes current working directory is project root unless overridden
 if ~exist(fullfile(projectRoot, 'src'), 'dir') || ~exist(fullfile(projectRoot, 'data'), 'dir')
     error(['Project structure not found. Please ensure MATLAB''s "Current Folder" is set to your ' ...
            'main project root directory before running. Current directory is: %s'], projectRoot);
@@ -413,4 +420,5 @@ if ~isempty(X_train_for_mean_spectra)
     fprintf('Mean spectra plot with highlighted features saved to: %s.(fig/tiff)\n', meanSpectraPlotFilenameBase);
 else
     fprintf('Skipping mean spectra plot due to missing training data for plotting.\n');
+end
 end


### PR DESCRIPTION
## Summary
- convert main Phase 2–4 driver scripts into functions
- remove workspace clearing from these entry points
- provide a simple `main.m` wrapper for one-click execution

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68418a38951883338e5c0dc05f083a63