### PR TITLE
Create reusable project path helper

### DIFF
--- a/archive/run_compare_baselineLDA_test_vs_cv.m
+++ b/archive/run_compare_baselineLDA_test_vs_cv.m
@@ -13,22 +13,13 @@
 clear; clc; close all;
 fprintf('COMPARING BaselineLDA: Test Set vs. Nested CV Performance - %s\n', string(datetime('now')));
 
-% --- Define Paths (Simplified) ---
-projectRoot = pwd; % Assumes current working directory IS the project root.
-if ~exist(fullfile(projectRoot, 'src'), 'dir') || ~exist(fullfile(projectRoot, 'data'), 'dir')
-    error(['Project structure not found. Please ensure MATLAB''s "Current Folder" is set to your ' ...
-           'main project root directory before running. Current directory is: %s'], projectRoot);
-end
+% --- Define Paths ---
+P = setup_project_paths();
 
-srcPath       = fullfile(projectRoot, 'src');
-helperFunPath = fullfile(srcPath, 'helper_functions');
-if ~exist(helperFunPath, 'dir')
-    error('The ''helper_functions'' directory was not found inside ''%s''.', srcPath);
-end
-addpath(helperFunPath);
+addpath(P.helperFunPath);
 
-dataPath      = fullfile(projectRoot, 'data');
-resultsPath   = fullfile(projectRoot, 'results'); % For loading Phase 2 results
+dataPath    = P.dataPath;
+resultsPath = P.resultsPath; % For loading Phase 2 results
 
 dateStr = string(datetime('now','Format','yyyyMMdd')); % For any new outputs if needed
 

--- a/archive/run_phase2_model_selection.m
+++ b/archive/run_phase2_model_selection.m
@@ -13,26 +13,15 @@
 %% 0. Initialization
 fprintf('PHASE 2: Model and Feature Selection - %s\n', string(datetime('now')));
 
-% --- Define Paths (Simplified) ---
-projectRoot = pwd; % Assumes current working directory IS the project root.
-if ~exist(fullfile(projectRoot, 'src'), 'dir') || ~exist(fullfile(projectRoot, 'data'), 'dir')
-    error(['Project structure not found. Please ensure MATLAB''s "Current Folder" is set to your ' ...
-           'main project root directory before running. Current directory is: %s'], projectRoot);
-end
+% --- Define Paths ---
+P = setup_project_paths();
 
-srcPath       = fullfile(projectRoot, 'src');
-helperFunPath = fullfile(srcPath, 'helper_functions');
-if ~exist(helperFunPath, 'dir')
-    error('The ''helper_functions'' directory was not found inside ''%s''.', srcPath);
-end
-addpath(helperFunPath);
+addpath(P.helperFunPath);
 
-% ***** THIS IS THE CRUCIAL ADDITION/CORRECTION *****
-dataPath      = fullfile(projectRoot, 'data'); % Define dataPath
-resultsPath   = fullfile(projectRoot, 'results', 'Phase2'); % Specific to Phase 2
-modelsPath    = fullfile(projectRoot, 'models', 'Phase2');   % Specific to Phase 2
-figuresPath   = fullfile(projectRoot, 'figures', 'Phase2'); % Specific to Phase 2
-% ***************************************************
+dataPath    = P.dataPath; % Define dataPath
+resultsPath = fullfile(P.resultsPath, 'Phase2'); % Specific to Phase 2
+modelsPath  = fullfile(P.modelsPath, 'Phase2');
+figuresPath = fullfile(P.figuresPath, 'Phase2');
 
 if ~exist(resultsPath, 'dir'), mkdir(resultsPath); end
 if ~exist(modelsPath, 'dir'), mkdir(modelsPath); end

--- a/archive/run_phase2_model_selection_comprehensive.m
+++ b/archive/run_phase2_model_selection_comprehensive.m
@@ -14,26 +14,17 @@
 %% 0. Initialization
 fprintf('PHASE 2: Model and Feature Selection (Comprehensive Outlier Strategy Comparison) - %s\n', string(datetime('now')));
 
-% --- Define Paths (Simplified) ---
-projectRoot = pwd; % Assumes current working directory IS the project root.
-if ~exist(fullfile(projectRoot, 'src'), 'dir') || ~exist(fullfile(projectRoot, 'data'), 'dir')
-    error(['Project structure not found. Please ensure MATLAB''s "Current Folder" is set to your ' ...
-           'main project root directory before running. Current directory is: %s'], projectRoot);
-end
+% --- Define Paths ---
+P = setup_project_paths();
 
-srcPath       = fullfile(projectRoot, 'src');
-helperFunPath = fullfile(srcPath, 'helper_functions');
-if ~exist(helperFunPath, 'dir')
-    error('The ''helper_functions'' directory was not found inside ''%s''.', srcPath);
-end
-addpath(helperFunPath);
+addpath(P.helperFunPath);
 
-dataPath      = fullfile(projectRoot, 'data');
-resultsPath   = fullfile(projectRoot, 'results', 'Phase2'); % Specific to Phase 2
-modelsPath    = fullfile(projectRoot, 'models', 'Phase2');   % Specific to Phase 2
-figuresPath   = fullfile(projectRoot, 'figures', 'Phase2'); % Specific to Phase 2
+dataPath    = P.dataPath;
+resultsPath = fullfile(P.resultsPath, 'Phase2'); % Specific to Phase 2
+modelsPath  = fullfile(P.modelsPath, 'Phase2');   % Specific to Phase 2
+figuresPath = fullfile(P.figuresPath, 'Phase2'); % Specific to Phase 2
 % For new comparison figures
-comparisonFiguresPath = fullfile(projectRoot, 'figures', 'OutlierStrategyComparison');
+comparisonFiguresPath = fullfile(P.figuresPath, 'OutlierStrategyComparison');
 if ~exist(comparisonFiguresPath, 'dir'), mkdir(comparisonFiguresPath); end
 
 

--- a/generate_phase1_figures.m
+++ b/generate_phase1_figures.m
@@ -12,14 +12,12 @@ clear; clc; close all;
 fprintf('Generating Phase 1 Dissertation Figures - %s\n', string(datetime('now')));
 
 % --- Define Paths ---
-projectRoot = pwd; 
-if ~exist(fullfile(projectRoot, 'src'), 'dir') || ~exist(fullfile(projectRoot, 'data'), 'dir')
-    error(['Project structure not found. Please ensure MATLAB''s "Current Folder" is set to your ' ...
-           'main project root directory. Current directory is: %s'], projectRoot);
-end
+P = setup_project_paths();
 
-dataPath      = fullfile(projectRoot, 'data');
-figuresPath   = fullfile(projectRoot, 'figures', 'Phase1_Dissertation_Plots');
+addpath(P.helperFunPath);
+
+dataPath    = P.dataPath;
+figuresPath = fullfile(P.figuresPath, 'Phase1_Dissertation_Plots');
 if ~exist(figuresPath, 'dir'), mkdir(figuresPath); end
 dateStrForFilenames = string(datetime('now','Format','yyyyMMdd'));
 
@@ -275,10 +273,10 @@ end
 outlier_plots_data_ready = false; % Flag to indicate if data for these plots is loaded
 try
     fprintf('\nLoading data for Outlier Figures 3, 4, 5...\n');
-    outlierResultsDir = fullfile(projectRoot, 'results'); 
+    outlierResultsDir = P.resultsPath;
     outlierInfoFiles = dir(fullfile(outlierResultsDir, '*_PCA_HotellingT2_Q_OutlierInfo.mat')); % Search in main results for now
     if isempty(outlierInfoFiles) % Try Phase1_Plots subfolder too
-        outlierInfoFiles = dir(fullfile(projectRoot, 'results', 'Phase1_Plots', '*_PCA_HotellingT2_Q_OutlierInfo.mat'));
+        outlierInfoFiles = dir(fullfile(P.resultsPath, 'Phase1_Plots', '*_PCA_HotellingT2_Q_OutlierInfo.mat'));
     end
     if isempty(outlierInfoFiles)
         error('No outlier info file (*_PCA_HotellingT2_Q_OutlierInfo.mat) found.');

--- a/helper_functions/setup_project_paths.m
+++ b/helper_functions/setup_project_paths.m
@@ -1,0 +1,51 @@
+function P = setup_project_paths()
+% SETUP_PROJECT_PATHS Validate project root and construct common directories.
+%
+%   P = SETUP_PROJECT_PATHS() checks that the current working directory
+%   contains the expected project folders ('src' and 'data'). It returns a
+%   struct with useful paths and ensures base result directories exist.
+%   The helper function directory is added to the MATLAB path.
+%
+%   Fields in P:
+%       projectRoot   - absolute path to the project root (pwd)
+%       srcPath       - path to the 'src' directory
+%       helperFunPath - path to 'src/helper_functions'
+%       dataPath      - path to the 'data' directory
+%       resultsPath   - path to the 'results' directory
+%       modelsPath    - path to the 'models' directory
+%       figuresPath   - path to the 'figures' directory
+%
+%   Example:
+%       P = setup_project_paths();
+%       modelsP2 = fullfile(P.modelsPath, 'Phase2');
+%
+%   Date: 2025-05-20
+
+    projectRoot = pwd;
+    if ~exist(fullfile(projectRoot, 'src'), 'dir') || ...
+       ~exist(fullfile(projectRoot, 'data'), 'dir')
+        error(['Project structure not found. Please run scripts from the ' ...
+               'project root. Current directory is: %s'], projectRoot);
+    end
+
+    P.projectRoot   = projectRoot;
+    P.srcPath       = fullfile(projectRoot, 'src');
+    P.helperFunPath = fullfile(P.srcPath, 'helper_functions');
+    P.dataPath      = fullfile(projectRoot, 'data');
+    P.resultsPath   = fullfile(projectRoot, 'results');
+    P.modelsPath    = fullfile(projectRoot, 'models');
+    P.figuresPath   = fullfile(projectRoot, 'figures');
+
+    baseDirs = {P.resultsPath, P.modelsPath, P.figuresPath};
+    for i = 1:numel(baseDirs)
+        if ~isfolder(baseDirs{i})
+            mkdir(baseDirs{i});
+        end
+    end
+
+    if exist(P.helperFunPath, 'dir')
+        addpath(P.helperFunPath);
+    else
+        error('Helper functions directory not found: %s', P.helperFunPath);
+    end
+end

--- a/import_preprocessing/run_apply_consensus_outlier_strategy.m
+++ b/import_preprocessing/run_apply_consensus_outlier_strategy.m
@@ -20,9 +20,12 @@
 clear; clc; close all;
 fprintf('Applying Consensus Outlier Strategy - %s\n', string(datetime('now')));
 
-projectRoot = pwd;
-dataPath    = fullfile(projectRoot, 'data');
-resultsPath = fullfile(projectRoot, 'results'); % Where outlierInfo and cleaned tables are
+P = setup_project_paths();
+
+addpath(P.helperFunPath);
+
+dataPath    = P.dataPath;
+resultsPath = P.resultsPath; % Where outlierInfo and cleaned tables are
 if ~exist(resultsPath, 'dir'), mkdir(resultsPath); end
 dateStr = string(datetime('now','Format','yyyyMMdd'));
 

--- a/import_preprocessing/run_comprehensive_outlier_processing.m
+++ b/import_preprocessing/run_comprehensive_outlier_processing.m
@@ -16,16 +16,13 @@ clear; clc; close all;
 fprintf('COMPREHENSIVE OUTLIER PROCESSING (T2/Q OR & AND Strategies) - START %s\n', string(datetime('now')));
 
 % --- Define Paths ---
-projectRoot = pwd;
-if ~exist(fullfile(projectRoot, 'src'), 'dir') || ~exist(fullfile(projectRoot, 'data'), 'dir')
-    error('Project structure not found. Run from project root. Current: %s', projectRoot);
-end
+P_base = setup_project_paths();
 
-P.dataPath = fullfile(projectRoot, 'data');
-P.resultsPath_OutlierExploration = fullfile(projectRoot, 'results', 'Phase1_OutlierExploration'); % For the main .mat analysis file
-P.resultsPath_OutlierApplication = fullfile(projectRoot, 'results'); % For cleaned tables, CSVs
-P.figuresPath_OutlierExploration = fullfile(projectRoot, 'figures', 'Phase1_OutlierExploration'); % For all plots
-P.helperFunPath = fullfile(projectRoot, 'src', 'helper_functions');
+P.dataPath = P_base.dataPath;
+P.resultsPath_OutlierExploration = fullfile(P_base.resultsPath, 'Phase1_OutlierExploration'); % For the main .mat analysis file
+P.resultsPath_OutlierApplication = P_base.resultsPath; % For cleaned tables, CSVs
+P.figuresPath_OutlierExploration = fullfile(P_base.figuresPath, 'Phase1_OutlierExploration'); % For all plots
+P.helperFunPath = P_base.helperFunPath;
 
 % Create directories if they don't exist
 dirPathsToEnsure = {P.resultsPath_OutlierExploration, P.resultsPath_OutlierApplication, P.figuresPath_OutlierExploration};

--- a/plotting/run_visualize_project_results.m
+++ b/plotting/run_visualize_project_results.m
@@ -10,28 +10,28 @@ fprintf('GENERATING PROJECT VISUALIZATIONS (Phases 2-4) - %s\n', string(datetime
 clear; clc; close all;
 
 % --- Define Paths ---
-currentScriptPath = fileparts(mfilename('fullpath')); 
-projectRoot = fileparts(fileparts(currentScriptPath)); 
-fprintf('INFO: Project root assumed to be: %s\n', projectRoot);
+P = setup_project_paths();
 
-resultsPath_main = fullfile(projectRoot, 'results');
-comparisonResultsPath_P2 = fullfile(resultsPath_main, 'OutlierStrategyComparison'); 
+addpath(P.helperFunPath);
+
+resultsPath_main = P.resultsPath;
+comparisonResultsPath_P2 = fullfile(resultsPath_main, 'OutlierStrategyComparison');
 
 resultsPath_P3 = fullfile(resultsPath_main, 'Phase3');
 resultsPath_P4 = fullfile(resultsPath_main, 'Phase4');
-modelsPath_P3 = fullfile(projectRoot, 'models', 'Phase3');
+modelsPath_P3 = fullfile(P.modelsPath, 'Phase3');
 
-figuresPath_output = fullfile(projectRoot, 'figures', 'ProjectSummaryFigures'); 
+figuresPath_output = fullfile(P.figuresPath, 'ProjectSummaryFigures');
 if ~isfolder(figuresPath_output), mkdir(figuresPath_output); end
 
-comparisonFiguresPath = fullfile(projectRoot, 'figures', 'OutlierStrategyComparison_Plots_From_VisualizeScript');
+comparisonFiguresPath = fullfile(P.figuresPath, 'OutlierStrategyComparison_Plots_From_VisualizeScript');
 if ~isfolder(comparisonFiguresPath), mkdir(comparisonFiguresPath); end
 
 dateStrForFilenames = string(datetime('now','Format','yyyyMMdd'));
 
-plottingHelpersPath = fullfile(projectRoot, 'plotting'); 
+plottingHelpersPath = fullfile(P.projectRoot, 'plotting');
 if exist(plottingHelpersPath, 'dir')
-    addpath(plottingHelpersPath); 
+    addpath(plottingHelpersPath);
     fprintf('Added to path: %s\n', plottingHelpersPath);
 else
     warning('Plotting helpers path not found: %s. Ensure spider_plot_R2019b.m is on the MATLAB path or in this directory.', plottingHelpersPath);

--- a/plotting/side_quest_visualize_binning_effects.m
+++ b/plotting/side_quest_visualize_binning_effects.m
@@ -9,20 +9,12 @@
 clear; clc; close all;
 fprintf('Visualizing Binning Effects - %s\n', string(datetime('now')));
 
-% --- Define Paths (Simplified) ---
-projectRoot = pwd; % Assumes current working directory IS the project root.
-if ~exist(fullfile(projectRoot, 'src'), 'dir') || ~exist(fullfile(projectRoot, 'data'), 'dir')
-    error(['Project structure not found. Please ensure MATLAB''s "Current Folder" is set to your ' ...
-           'main project root directory before running. Current directory is: %s'], projectRoot);
-end
-srcPath       = fullfile(projectRoot, 'src');
-helperFunPath = fullfile(srcPath, 'helper_functions');
-if ~exist(helperFunPath, 'dir')
-    error('The ''helper_functions'' directory was not found inside ''%s''.', srcPath);
-end
-addpath(helperFunPath); % For bin_spectra function
-dataPath      = fullfile(projectRoot, 'data');
-figuresPath   = fullfile(projectRoot, 'figures', 'SideQuests'); % New folder for this plot
+% --- Define Paths ---
+P = setup_project_paths();
+
+dataPath    = P.dataPath;
+figuresPath = fullfile(P.figuresPath, 'SideQuests'); % New folder for this plot
+addpath(P.helperFunPath); % For bin_spectra function
 if ~exist(figuresPath, 'dir'), mkdir(figuresPath); end
 dateStr = string(datetime('now','Format','yyyyMMdd'));
 

--- a/run_phase2_model_selection_comparative.m
+++ b/run_phase2_model_selection_comparative.m
@@ -13,22 +13,16 @@ fprintf('PHASE 2: Model Selection & Outlier Strategy Comparison - %s\n', string(
 clear; clc; close all;
 
 % --- Define Paths ---
-projectRoot = pwd; 
-if ~exist(fullfile(projectRoot, 'src'), 'dir') || ~exist(fullfile(projectRoot, 'data'), 'dir')
-    error('Project structure not found. Run from project root. Current: %s', projectRoot);
-end
+P = setup_project_paths();
 
-srcPath       = fullfile(projectRoot, 'src');
-helperFunPath = fullfile(srcPath, 'helper_functions');
-if ~exist(helperFunPath, 'dir'), error('Helper functions directory not found: %s', helperFunPath); end
-addpath(helperFunPath);
+addpath(P.helperFunPath);
 
-dataPath      = fullfile(projectRoot, 'data');
-resultsPath   = fullfile(projectRoot, 'results', 'Phase2'); 
-modelsPath    = fullfile(projectRoot, 'models', 'Phase2');   
-figuresPath   = fullfile(projectRoot, 'figures', 'Phase2'); 
-comparisonFiguresPath = fullfile(projectRoot, 'figures', 'OutlierStrategyComparison'); % For new comparison plots
-comparisonResultsPath = fullfile(projectRoot, 'results', 'OutlierStrategyComparison'); % For new comparison tables/data
+dataPath    = P.dataPath;
+resultsPath = fullfile(P.resultsPath, 'Phase2');
+modelsPath  = fullfile(P.modelsPath, 'Phase2');
+figuresPath = fullfile(P.figuresPath, 'Phase2');
+comparisonFiguresPath = fullfile(P.figuresPath, 'OutlierStrategyComparison'); % For new comparison plots
+comparisonResultsPath = fullfile(P.resultsPath, 'OutlierStrategyComparison');   % For new comparison tables/data
 
 dirToEnsure = {resultsPath, modelsPath, figuresPath, comparisonFiguresPath, comparisonResultsPath};
 for i=1:length(dirToEnsure), if ~isfolder(dirToEnsure{i}), mkdir(dirToEnsure{i}); end, end

--- a/run_phase3_final_evaluation.m
+++ b/run_phase3_final_evaluation.m
@@ -11,24 +11,15 @@
 clear; clc; close all;
 fprintf('PHASE 3: Final Model Training & Unbiased Evaluation - %s\n', string(datetime('now')));
 
-% --- Define Paths (Simplified) ---
-projectRoot = pwd; % Assumes current working directory IS the project root.
-if ~exist(fullfile(projectRoot, 'src'), 'dir') || ~exist(fullfile(projectRoot, 'data'), 'dir')
-    error(['Project structure not found. Please ensure MATLAB''s "Current Folder" is set to your ' ...
-           'main project root directory before running. Current directory is: %s'], projectRoot);
-end
+% --- Define Paths ---
+P = setup_project_paths();
 
-srcPath       = fullfile(projectRoot, 'src');
-helperFunPath = fullfile(srcPath, 'helper_functions');
-if ~exist(helperFunPath, 'dir')
-    error('The ''helper_functions'' directory was not found inside ''%s''.', srcPath);
-end
-addpath(helperFunPath);
+addpath(P.helperFunPath);
 
-dataPath      = fullfile(projectRoot, 'data');
-resultsPath   = fullfile(projectRoot, 'results', 'Phase3'); % Specific to Phase 3
-modelsPath    = fullfile(projectRoot, 'models', 'Phase3');   % Specific to Phase 3
-figuresPath   = fullfile(projectRoot, 'figures', 'Phase3'); % Specific to Phase 3
+dataPath    = P.dataPath;
+resultsPath = fullfile(P.resultsPath, 'Phase3');
+modelsPath  = fullfile(P.modelsPath, 'Phase3');
+figuresPath = fullfile(P.figuresPath, 'Phase3');
 
 if ~exist(resultsPath, 'dir'), mkdir(resultsPath); end
 if ~exist(modelsPath, 'dir'), mkdir(modelsPath); end

--- a/run_phase3_final_evaluation_OR_strategy.m
+++ b/run_phase3_final_evaluation_OR_strategy.m
@@ -16,24 +16,15 @@ clear; clc; close all;
 fprintf('PHASE 3: Final Model Training & Unbiased Evaluation (T2 OR Q Strategy) - %s\n', string(datetime('now')));
 
 % --- Define Paths ---
-projectRoot = pwd; 
-if ~exist(fullfile(projectRoot, 'src'), 'dir') || ~exist(fullfile(projectRoot, 'data'), 'dir')
-    error(['Project structure not found. Please ensure MATLAB''s "Current Folder" is set to your ' ...
-           'main project root directory before running. Current directory is: %s'], projectRoot);
-end
+P = setup_project_paths();
 
-srcPath       = fullfile(projectRoot, 'src');
-helperFunPath = fullfile(srcPath, 'helper_functions');
-if ~exist(helperFunPath, 'dir')
-    error('The ''helper_functions'' directory was not found inside ''%s''.', srcPath);
-end
-addpath(helperFunPath);
+addpath(P.helperFunPath);
 
-dataPath         = fullfile(projectRoot, 'data');
-phase2ModelsPath = fullfile(projectRoot, 'models', 'Phase2'); % For loading best hyperparameters
-resultsPath_P3   = fullfile(projectRoot, 'results', 'Phase3'); % General Phase 3 results
-modelsPath_P3    = fullfile(projectRoot, 'models', 'Phase3');   
-figuresPath_P3   = fullfile(projectRoot, 'figures', 'Phase3'); 
+dataPath         = P.dataPath;
+phase2ModelsPath = fullfile(P.modelsPath, 'Phase2'); % For loading best hyperparameters
+resultsPath_P3   = fullfile(P.resultsPath, 'Phase3'); % General Phase 3 results
+modelsPath_P3    = fullfile(P.modelsPath, 'Phase3');
+figuresPath_P3   = fullfile(P.figuresPath, 'Phase3');
 
 if ~exist(resultsPath_P3, 'dir'), mkdir(resultsPath_P3); end
 if ~exist(modelsPath_P3, 'dir'), mkdir(modelsPath_P3); end

--- a/run_phase4_feature_interpretation.m
+++ b/run_phase4_feature_interpretation.m
@@ -11,17 +11,15 @@
 clear; clc; close all;
 fprintf('PHASE 4: Feature Interpretation - %s\n', string(datetime('now')));
 
-% --- Define Paths (Simplified) ---
-projectRoot = pwd; % Assumes current working directory IS the project root.
-if ~exist(fullfile(projectRoot, 'src'), 'dir') || ~exist(fullfile(projectRoot, 'data'), 'dir')
-    error(['Project structure not found. Please ensure MATLAB''s "Current Folder" is set to your ' ...
-           'main project root directory before running. Current directory is: %s'], projectRoot);
-end
+% --- Define Paths ---
+P = setup_project_paths();
 
-dataPath      = fullfile(projectRoot, 'data');
-modelsPath    = fullfile(projectRoot, 'models', 'Phase3');
-resultsPath   = fullfile(projectRoot, 'results', 'Phase4'); % Specific to Phase 4
-figuresPath   = fullfile(projectRoot, 'figures', 'Phase4'); % Specific to Phase 4
+addpath(P.helperFunPath);
+
+dataPath    = P.dataPath;
+modelsPath  = fullfile(P.modelsPath, 'Phase3');
+resultsPath = fullfile(P.resultsPath, 'Phase4'); % Specific to Phase 4
+figuresPath = fullfile(P.figuresPath, 'Phase4'); % Specific to Phase 4
 
 if ~exist(resultsPath, 'dir'), mkdir(resultsPath); end
 if ~exist(figuresPath, 'dir'), mkdir(figuresPath); end


### PR DESCRIPTION
## Summary
- add `setup_project_paths` helper to collect standard project folders
- update all main and archived scripts to call this function
- scripts now add helper paths using the returned struct

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68418a37e8188333ba4b864f7c7822a0