### PR TITLE
Add project root helper and update export scripts

### DIFF
--- a/data_management/export_filenames_matlab_structures.m
+++ b/data_management/export_filenames_matlab_structures.m
@@ -1,10 +1,24 @@
-files = dir('C:\Users\Franz\OneDrive\01_Promotion\01 Data\meningioma-ftir-classification\results\Phase3');
+%% export_filenames_matlab_structures.m
+%
+% Lists all files in the Phase3 results folder and prints the variables
+% contained in each MAT-file. The project root is determined using the
+% helper `get_project_root`, which defaults to the current working
+% directory or can be overridden with the PROJECT_ROOT environment
+% variable.
+%
+% Example:
+%   projectRoot = get_project_root();
+%   folderPath  = fullfile(projectRoot, 'results', 'Phase3');
+%
+projectRoot = get_project_root();
+folderPath  = fullfile(projectRoot, 'results', 'Phase3');
+
+files = dir(folderPath);
 files = files(~[files.isdir]);
 for i = 1:length(files)
     disp(files(i).name);
 end
-%%
-folderPath = 'C:\Users\Franz\OneDrive\01_Promotion\01 Data\meningioma-ftir-classification\results\Phase3';  % change as needed
+%% Inspect variables inside MAT-files
 files = dir(fullfile(folderPath, '*.mat'));
 
 for i = 1:length(files)

--- a/data_management/export_filenames_matlab_structures_results.m
+++ b/data_management/export_filenames_matlab_structures_results.m
@@ -1,10 +1,24 @@
-files = dir('C:\Users\Franz\OneDrive\01_Promotion\01 Data\meningioma-ftir-classification\results');
+%% export_filenames_matlab_structures_results.m
+%
+% Lists all files in the main results folder and prints the variables
+% contained in each MAT-file. The folder location is resolved relative to
+% the project root using `get_project_root`. Set the PROJECT_ROOT
+% environment variable to override the default of using the current working
+% directory.
+%
+% Example:
+%   projectRoot = get_project_root();
+%   folderPath  = fullfile(projectRoot, 'results');
+%
+projectRoot = get_project_root();
+folderPath  = fullfile(projectRoot, 'results');
+
+files = dir(folderPath);
 files = files(~[files.isdir]);
 for i = 1:length(files)
     disp(files(i).name);
 end
-%%
-folderPath = 'C:\Users\Franz\OneDrive\01_Promotion\01 Data\meningioma-ftir-classification\results';  % change as needed
+%% Inspect variables inside MAT-files
 files = dir(fullfile(folderPath, '*.mat'));
 
 for i = 1:length(files)

--- a/helper_functions/get_project_root.m
+++ b/helper_functions/get_project_root.m
@@ -1,0 +1,22 @@
+%% get_project_root.m
+%
+% Helper function to determine the base directory of the project.
+% The function first checks the environment variable PROJECT_ROOT. If it
+% is set and not empty, that value is returned. Otherwise, the current
+% working directory (pwd) is returned. This allows scripts to be run from
+% anywhere while still locating project files.
+%
+% Example usage:
+%   projectRoot = get_project_root();
+%   resultsDir  = fullfile(projectRoot, 'results');
+%
+% Date: 2025-05-15
+%
+function rootDir = get_project_root()
+    envDir = getenv('PROJECT_ROOT');
+    if ~isempty(envDir)
+        rootDir = envDir;
+    else
+        rootDir = pwd;
+    end
+end


### PR DESCRIPTION
## Summary
- create `get_project_root` helper to resolve project root via `PROJECT_ROOT` env var or `pwd`
- update export scripts to build paths relative to the project root
- document new usage in script comments

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68418a3637488333b520ab08439ff5e6