### PR TITLE
Guard helper path additions

### DIFF
--- a/archive/run_compare_baselineLDA_test_vs_cv.m
+++ b/archive/run_compare_baselineLDA_test_vs_cv.m
@@ -25,7 +25,9 @@ helperFunPath = fullfile(srcPath, 'helper_functions');
 if ~exist(helperFunPath, 'dir')
     error('The ''helper_functions'' directory was not found inside ''%s''.', srcPath);
 end
-addpath(helperFunPath);
+if ~contains(path, helperFunPath)
+    addpath(helperFunPath);
+end
 
 dataPath      = fullfile(projectRoot, 'data');
 resultsPath   = fullfile(projectRoot, 'results'); % For loading Phase 2 results

--- a/archive/run_phase2_model_selection.m
+++ b/archive/run_phase2_model_selection.m
@@ -25,7 +25,9 @@ helperFunPath = fullfile(srcPath, 'helper_functions');
 if ~exist(helperFunPath, 'dir')
     error('The ''helper_functions'' directory was not found inside ''%s''.', srcPath);
 end
-addpath(helperFunPath);
+if ~contains(path, helperFunPath)
+    addpath(helperFunPath);
+end
 
 % ***** THIS IS THE CRUCIAL ADDITION/CORRECTION *****
 dataPath      = fullfile(projectRoot, 'data'); % Define dataPath

--- a/archive/run_phase2_model_selection_comprehensive.m
+++ b/archive/run_phase2_model_selection_comprehensive.m
@@ -26,7 +26,9 @@ helperFunPath = fullfile(srcPath, 'helper_functions');
 if ~exist(helperFunPath, 'dir')
     error('The ''helper_functions'' directory was not found inside ''%s''.', srcPath);
 end
-addpath(helperFunPath);
+if ~contains(path, helperFunPath)
+    addpath(helperFunPath);
+end
 
 dataPath      = fullfile(projectRoot, 'data');
 resultsPath   = fullfile(projectRoot, 'results', 'Phase2'); % Specific to Phase 2

--- a/import_preprocessing/run_comprehensive_outlier_processing.m
+++ b/import_preprocessing/run_comprehensive_outlier_processing.m
@@ -32,7 +32,9 @@ dirPathsToEnsure = {P.resultsPath_OutlierExploration, P.resultsPath_OutlierAppli
 for i = 1:length(dirPathsToEnsure)
     if ~isfolder(dirPathsToEnsure{i}), mkdir(dirPathsToEnsure{i}); end
 end
-addpath(P.helperFunPath);
+if ~contains(path, P.helperFunPath)
+    addpath(P.helperFunPath);
+end
 
 % --- Parameters ---
 P.datePrefix = string(datetime('now','Format','yyyyMMdd'));

--- a/plotting/side_quest_visualize_binning_effects.m
+++ b/plotting/side_quest_visualize_binning_effects.m
@@ -20,7 +20,9 @@ helperFunPath = fullfile(srcPath, 'helper_functions');
 if ~exist(helperFunPath, 'dir')
     error('The ''helper_functions'' directory was not found inside ''%s''.', srcPath);
 end
-addpath(helperFunPath); % For bin_spectra function
+if ~contains(path, helperFunPath)
+    addpath(helperFunPath); % For bin_spectra function
+end
 dataPath      = fullfile(projectRoot, 'data');
 figuresPath   = fullfile(projectRoot, 'figures', 'SideQuests'); % New folder for this plot
 if ~exist(figuresPath, 'dir'), mkdir(figuresPath); end

--- a/run_phase2_model_selection_comparative.m
+++ b/run_phase2_model_selection_comparative.m
@@ -30,8 +30,12 @@ end
 
 srcPath       = fullfile(projectRoot, 'src');
 helperFunPath = fullfile(srcPath, 'helper_functions');
-if ~exist(helperFunPath, 'dir'), error('Helper functions directory not found: %s', helperFunPath); end
-addpath(helperFunPath);
+if ~exist(helperFunPath, 'dir')
+    error('Helper functions directory not found: %s', helperFunPath);
+end
+if ~contains(path, helperFunPath)
+    addpath(helperFunPath);
+end
 
 dataPath      = fullfile(projectRoot, 'data');
 resultsPath   = fullfile(projectRoot, 'results', 'Phase2'); 

--- a/run_phase3_final_evaluation.m
+++ b/run_phase3_final_evaluation.m
@@ -30,7 +30,9 @@ helperFunPath = fullfile(srcPath, 'helper_functions');
 if ~exist(helperFunPath, 'dir')
     error('The ''helper_functions'' directory was not found inside ''%s''.', srcPath);
 end
-addpath(helperFunPath);
+if ~contains(path, helperFunPath)
+    addpath(helperFunPath);
+end
 
 dataPath      = fullfile(projectRoot, 'data');
 resultsPath   = fullfile(projectRoot, 'results', 'Phase3'); % Specific to Phase 3

--- a/run_phase3_final_evaluation_OR_strategy.m
+++ b/run_phase3_final_evaluation_OR_strategy.m
@@ -34,7 +34,9 @@ helperFunPath = fullfile(srcPath, 'helper_functions');
 if ~exist(helperFunPath, 'dir')
     error('The ''helper_functions'' directory was not found inside ''%s''.', srcPath);
 end
-addpath(helperFunPath);
+if ~contains(path, helperFunPath)
+    addpath(helperFunPath);
+end
 
 dataPath         = fullfile(projectRoot, 'data');
 phase2ModelsPath = fullfile(projectRoot, 'models', 'Phase2'); % For loading best hyperparameters


### PR DESCRIPTION
## Summary
- avoid redundant `addpath` calls in phase scripts
- check for helper path before adding it

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684196e3da588333a057cf7cb9eeacdc