### PR TITLE
Refactor MRMR to skip binning

### DIFF
--- a/run_phase2_model_selection_comparative.m
+++ b/run_phase2_model_selection_comparative.m
@@ -149,9 +149,15 @@ for iStrategy = 1:length(outlierStrategiesToCompare)
         p.binningFactors = [1, 2, 4, 8, 16]; p.pcaVarianceToExplain_range = [0.90, 0.95, 0.99];
         pipelineIdx = pipelineIdx + 1; pipelines{pipelineIdx} = p;
         % --- Pipeline 4: MRMR + LDA ---
-        p = struct(); p.name = 'MRMRLDA'; p.feature_selection_method = 'mrmr'; p.classifier = 'LDA';
-        p.hyperparameters_to_tune = {'binningFactor', 'numMRMRFeatures'};
-        p.binningFactors = [1, 2, 4, 8, 16]; p.numMRMRFeatures_range = [10, 20, 30, 40, 50];
+        % MRMR is performed on unbinned data. BinningFactor is fixed to 1 and
+        % not part of the hyperparameter search.
+        p = struct();
+        p.name = 'MRMRLDA';
+        p.feature_selection_method = 'mrmr';
+        p.classifier = 'LDA';
+        p.hyperparameters_to_tune = {'numMRMRFeatures'}; % only tune number of features
+        p.binningFactors = 1; % no binning applied for MRMR pipeline
+        p.numMRMRFeatures_range = [10, 20, 30, 40, 50];
         pipelineIdx = pipelineIdx + 1; pipelines{pipelineIdx} = p;
         
         overallComparisonResults.pipelines = pipelines; % Store pipeline definitions once

--- a/run_phase3_final_evaluation.m
+++ b/run_phase3_final_evaluation.m
@@ -114,7 +114,9 @@ end
 
 % --- Define Final Model Hyperparameters (MRMRLDA) ---
 % Based on Phase 2 results (mode of outerFoldBestHyperparams for MRMRLDA)
-final_binningFactor = 8;
+% Binning is not applied for MRMRLDA. Keep factor fixed at 1 to ensure
+% MRMR runs on the original (unbinned) spectra.
+final_binningFactor = 1;
 final_numMRMRFeatures = 50;
 fprintf('Final hyperparameters for MRMRLDA: Binning Factor = %d, Num MRMR Features = %d\n', ...
     final_binningFactor, final_numMRMRFeatures);
@@ -132,6 +134,7 @@ if final_binningFactor > 1
 else
     X_train_binned = X_train_full;
     wavenumbers_binned = wavenumbers_original;
+    fprintf('No binning applied. Using original training features.\n');
 end
 fprintf('Training data after binning: %d spectra, %d features.\n', size(X_train_binned,1), size(X_train_binned,2));
 
@@ -203,6 +206,7 @@ if final_binningFactor > 1
     [X_test_binned, ~] = bin_spectra(X_test_full, wavenumbers_original, final_binningFactor);
 else
     X_test_binned = X_test_full;
+    fprintf('No binning applied to test set. Using original features.\n');
 end
 fprintf('Test data after binning: %d spectra, %d features.\n', size(X_test_binned,1), size(X_test_binned,2));
 

--- a/run_phase3_final_evaluation_OR_strategy.m
+++ b/run_phase3_final_evaluation_OR_strategy.m
@@ -142,7 +142,8 @@ fprintf('Loading best hyperparameters for MRMRLDA (Strategy: OR) from Phase 2 mo
 bestHyperparamFilePattern_OR = fullfile(phase2ModelsPath, sprintf('*_Phase2_BestPipelineInfo_Strat_OR.mat'));
 bestHyperparamFiles_OR = dir(bestHyperparamFilePattern_OR);
 
-final_binningFactor = 8; % Default
+% MRMR is performed on unbinned data for the final model. Fix binning factor to 1.
+final_binningFactor = 1; % Default
 final_numMRMRFeatures = 50; % Default
 
 if isempty(bestHyperparamFiles_OR)
@@ -210,6 +211,7 @@ if final_binningFactor > 1
 else
     X_train_binned = X_train_full;
     wavenumbers_binned = wavenumbers_original;
+    fprintf('No binning applied. Using original training features.\n');
 end
 fprintf('Training data for OR strategy after binning: %d spectra, %d features.\n', size(X_train_binned,1), size(X_train_binned,2));
 
@@ -261,6 +263,7 @@ if final_binningFactor > 1
     [X_test_binned, ~] = bin_spectra(X_test_full, wavenumbers_original, final_binningFactor);
 else
     X_test_binned = X_test_full;
+    fprintf('No binning applied to test set. Using original features.\n');
 end
 fprintf('Test data after binning: %d spectra, %d features.\n', size(X_test_binned,1), size(X_test_binned,2));
 


### PR DESCRIPTION
## Summary
- tune only number of MRMR features and keep the data unbinned
- fix final evaluation scripts to always run MRMR on original spectra

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842d21d03748333ada3656f9a383b76