### PR TITLE
Add configuration helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ figures/         % generated plots
 - **Statistics and Machine Learning Toolbox** (for LDA, cross-validation and `fscmrmr`)
 - **Signal Processing Toolbox** (for spectral smoothing via Savitzky–Golay filtering)
 
+## Configuration helper
+
+Use the `configure_cfg.m` function to create or update the `cfg` structure that
+controls the main scripts. It fills in sensible defaults for missing fields and
+accepts name/value pairs for overrides.
+
+```matlab
+cfg = configure_cfg('outlierStrategy','OR');
+run_phase3_final_evaluation(cfg);
+```
+
 ## Analysis pipeline
 
 All scripts assume the MATLAB current folder is set to the project root. Each phase can be run independently once the required input files are available.

--- a/configure_cfg.m
+++ b/configure_cfg.m
@@ -1,0 +1,50 @@
+function cfg = configure_cfg(varargin)
+%CONFIGURE_CFG Create or update configuration struct for project scripts.
+%
+%   cfg = CONFIGURE_CFG() returns a struct with default fields.
+%   cfg = CONFIGURE_CFG(existingCfg) fills missing fields in existingCfg.
+%   cfg = CONFIGURE_CFG(...,'Name',Value) sets or overrides fields.
+%
+%   Recognised fields:
+%     projectRoot                - repository root path
+%     outlierStrategy            - default outlier strategy ('AND')
+%     outlierStrategiesToCompare - cell array of strategies for Phase 2
+%
+%   Example:
+%       cfg = configure_cfg('projectRoot','/path/to/project', ...
+%                           'outlierStrategy','OR');
+%
+% Date: 2025-06-06
+
+    if nargin > 0 && isstruct(varargin{1})
+        cfg = varargin{1};
+        args = varargin(2:end);
+    else
+        cfg = struct();
+        args = varargin;
+    end
+
+    if mod(numel(args),2) ~= 0
+        error('Name-value arguments must occur in pairs.');
+    end
+    for i = 1:2:numel(args)
+        name = args{i};
+        value = args{i+1};
+        cfg.(name) = value;
+    end
+
+    if ~isfield(cfg,'projectRoot') || isempty(cfg.projectRoot)
+        if exist('get_project_root','file')
+            cfg.projectRoot = get_project_root();
+        else
+            cfg.projectRoot = pwd;
+        end
+    end
+    if ~isfield(cfg,'outlierStrategy') || isempty(cfg.outlierStrategy)
+        cfg.outlierStrategy = 'AND';
+    end
+    if ~isfield(cfg,'outlierStrategiesToCompare') || isempty(cfg.outlierStrategiesToCompare)
+        cfg.outlierStrategiesToCompare = {'OR','AND'};
+    end
+end
+

--- a/main.m
+++ b/main.m
@@ -3,10 +3,10 @@
 % Simple wrapper script to run the key project phases using default
 % configuration settings.
 %
-% Users can modify the `cfg` structure below to customize paths or
-% parameters and then run this file for a one-click execution.
+% Users can modify the configuration via `configure_cfg` or by editing the
+% returned struct directly.
 
-cfg = struct();
+cfg = configure_cfg();
 
 run_phase2_model_selection_comparative(cfg);
 run_phase3_final_evaluation(cfg);


### PR DESCRIPTION
## Summary
- add `configure_cfg` helper for creating the cfg struct
- reference the new helper in `main.m`
- document configuration helper in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843175f95388333843a27cf1f3e9f3c