### PR TITLE
Handle empty hyperparameter entries

### DIFF
--- a/run_phase2_model_selection_comparative.m
+++ b/run_phase2_model_selection_comparative.m
@@ -506,10 +506,17 @@ function aggHyper = aggregate_best_hyperparams(hyperparamCell)
     if isempty(hyperparamCell)
         return;
     end
-    allFields = unique(cellfun(@fieldnames, hyperparamCell, 'UniformOutput', false));
-    if iscell(allFields)
-        allFields = unique([allFields{:}]);
+
+    % Filter to only non-empty struct entries to avoid errors with fieldnames
+    isValidStruct = cellfun(@(c) isstruct(c) && ~isempty(c), hyperparamCell);
+    hyperparamCell = hyperparamCell(isValidStruct);
+    if isempty(hyperparamCell)
+        return;
     end
+
+    allFieldsNested = cellfun(@fieldnames, hyperparamCell, 'UniformOutput', false);
+    allFields = unique([allFieldsNested{:}]);
+
     for f = 1:numel(allFields)
         fname = allFields{f};
         values = []; %#ok<AGROW>


### PR DESCRIPTION
## Summary
- make `aggregate_best_hyperparams` skip non‑struct or empty entries
- update field aggregation logic

## Testing
- `octave --silent --eval "run_phase2_model_selection_comparative(struct())"` *(fails: `datetime` undefined)*

------
https://chatgpt.com/codex/tasks/task_e_684361ba20488333b3daf85118031cb9