### PR TITLE
Limit Phase 2 to selected outlier strategy

### DIFF
--- a/main.m
+++ b/main.m
@@ -18,6 +18,9 @@ else
     cfg.outlierStrategy = 'OR';
 end
 
+% Ensure Phase 2 compares only the selected strategy
+cfg.outlierStrategiesToCompare = {cfg.outlierStrategy};
+
 run_phase2_model_selection_comparative(cfg);
 run_phase3_final_evaluation(cfg);
 run_phase4_feature_interpretation(cfg);


### PR DESCRIPTION
## Summary
- allow Phase 2 to receive single strategy selection

## Testing
- `octave --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843626001148333938f11166b358945