### PR TITLE
Add numFisherFeatures compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Optional scripts such as `run_outlier_detection_pca2.m` or `run_apply_consensus_
 
 Run nested cross-validation and compare outlier strategies using:
 The Fisher ratio and MRMR pipelines now select a percentage of the available features rather than a fixed count.
+If you still use the legacy `numFisherFeatures` option it will be converted
+internally and a warning will be displayed.
 
 ```matlab
 run('src/run_phase2_model_selection_comparative.m')

--- a/examples/test_perform_inner_cv_fieldnames.m
+++ b/examples/test_perform_inner_cv_fieldnames.m
@@ -1,0 +1,33 @@
+% TEST_PERFORM_INNER_CV_FIELDNAMES
+% Simple script verifying that perform_inner_cv accepts both
+% fisherFeaturePercent and the deprecated numFisherFeatures field.
+
+addpath('helper_functions');
+
+% Create a tiny synthetic classification problem with 6 probes
+% Each probe has two spectra and belongs to class 1 or 3
+X = rand(12,10);
+y = [ones(6,1); ones(6,1)*3];
+probeIDs = repelem((1:6)',2);
+wavenumbers = 1:10;
+
+metricNames = {'Accuracy'};
+numInnerFolds = 2;
+
+% -- Using fisherFeaturePercent --
+pipe = struct();
+pipe.feature_selection_method = 'fisher';
+pipe.classifier = 'lda';
+pipe.hyperparameters_to_tune = {'fisherFeaturePercent'};
+pipe.fisherFeaturePercent_range = 0.2;
+
+[hp1, metrics1] = perform_inner_cv(X, y, probeIDs, pipe, wavenumbers, numInnerFolds, metricNames);
+
+% -- Using deprecated numFisherFeatures --
+pipe.hyperparameters_to_tune = {'numFisherFeatures'};
+pipe.numFisherFeatures_range = 2;
+
+[hp2, metrics2] = perform_inner_cv(X, y, probeIDs, pipe, wavenumbers, numInnerFolds, metricNames);
+
+fprintf('Percent-based field result: %.2f\n', hp1.fisherFeaturePercent);
+fprintf('Deprecated field result -> percent: %.2f\n', hp2.fisherFeaturePercent);

--- a/helper_functions/perform_inner_cv.m
+++ b/helper_functions/perform_inner_cv.m
@@ -20,6 +20,9 @@ function [bestHyperparams, bestOverallPerfMetrics] = perform_inner_cv(...
             if ismember('fisherFeaturePercent', pipelineConfig.hyperparameters_to_tune)
                 paramGridCells{end+1} = pipelineConfig.fisherFeaturePercent_range(:)';
                 paramNames{end+1} = 'fisherFeaturePercent';
+            elseif ismember('numFisherFeatures', pipelineConfig.hyperparameters_to_tune)
+                paramGridCells{end+1} = pipelineConfig.numFisherFeatures_range(:)';
+                paramNames{end+1} = 'numFisherFeatures';
             end
         case 'pca'
             if ismember('pcaVarianceToExplain', pipelineConfig.hyperparameters_to_tune)
@@ -167,6 +170,13 @@ function [bestHyperparams, bestOverallPerfMetrics] = perform_inner_cv(...
 
             switch lower(pipelineConfig.feature_selection_method)
                 case 'fisher'
+                    % Allow legacy "numFisherFeatures" field by converting it to a percent
+                    if isfield(currentHyperparams, 'numFisherFeatures')
+                        warning('perform_inner_cv:DeprecatedField', ...
+                            ['numFisherFeatures is deprecated. Use fisherFeaturePercent instead. ', ...
+                             'Automatically converting for this run.']);
+                        currentHyperparams.fisherFeaturePercent = currentHyperparams.numFisherFeatures ./ size(X_train_p,2);
+                    end
                     numFeat = ceil(currentHyperparams.fisherFeaturePercent * size(X_train_p,2));
                     numFeat = min(numFeat, size(X_train_p,2));
                     if numFeat > 0 && size(X_train_p,1)>1 && length(unique(y_train_fold))==2


### PR DESCRIPTION
## Summary
- allow `numFisherFeatures` in inner CV helper
- warn when legacy field is used
- add example script showing both field names
- mention the legacy field in Phase 2 documentation

## Testing
- `octave examples/test_perform_inner_cv_fieldnames.m` *(fails: unique third output not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_684366ee4bc883338b1af55d2130d234