### PR TITLE
Fix fisher feature hyperparameter name

### DIFF
--- a/helper_functions/perform_inner_cv.m
+++ b/helper_functions/perform_inner_cv.m
@@ -167,7 +167,16 @@ function [bestHyperparams, bestOverallPerfMetrics] = perform_inner_cv(...
 
             switch lower(pipelineConfig.feature_selection_method)
                 case 'fisher'
-                    numFeat = ceil(currentHyperparams.fisherFeaturePercent * size(X_train_p,2));
+                    if isfield(currentHyperparams, 'fisherFeaturePercent')
+                        numFeat = ceil(currentHyperparams.fisherFeaturePercent * size(X_train_p,2));
+                    elseif isfield(currentHyperparams, 'numFisherFeatures')
+                        warning('perform_inner_cv:deprecatedField', ...
+                            ['numFisherFeatures is deprecated. Please update the pipeline to use ', ...
+                             'fisherFeaturePercent instead.']);
+                        numFeat = currentHyperparams.numFisherFeatures;
+                    else
+                        numFeat = size(X_train_p,2);
+                    end
                     numFeat = min(numFeat, size(X_train_p,2));
                     if numFeat > 0 && size(X_train_p,1)>1 && length(unique(y_train_fold))==2
                         fisherRatios_inner = calculate_fisher_ratio(X_train_p, y_train_fold);


### PR DESCRIPTION
## Summary
- ensure `perform_inner_cv` accepts the new `fisherFeaturePercent` field
- warn if old `numFisherFeatures` field is used

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68436aa90f94833396c3fa8f171cbeb9