### PR TITLE
Fix fisher feature parameter handling

### DIFF
--- a/helper_functions/perform_inner_cv.m
+++ b/helper_functions/perform_inner_cv.m
@@ -20,6 +20,11 @@ function [bestHyperparams, bestOverallPerfMetrics] = perform_inner_cv(...
             if ismember('fisherFeaturePercent', pipelineConfig.hyperparameters_to_tune)
                 paramGridCells{end+1} = pipelineConfig.fisherFeaturePercent_range(:)';
                 paramNames{end+1} = 'fisherFeaturePercent';
+            elseif ismember('numFisherFeatures', pipelineConfig.hyperparameters_to_tune)
+                % Backwards compatibility with older configs that tune a fixed
+                % number of Fisher features instead of a percentage
+                paramGridCells{end+1} = pipelineConfig.numFisherFeatures_range(:)';
+                paramNames{end+1} = 'numFisherFeatures';
             end
         case 'pca'
             if ismember('pcaVarianceToExplain', pipelineConfig.hyperparameters_to_tune)

--- a/run_phase2_model_selection_comparative.m
+++ b/run_phase2_model_selection_comparative.m
@@ -545,7 +545,13 @@ function [modelStruct, selectedIdx, selectedWn] = train_final_pipeline_model(X, 
         case 'fisher'
             fr = calculate_fisher_ratio(Xp, y);
             [~, order] = sort(fr,'descend','MissingPlacement','last');
-            numF = ceil(hp.fisherFeaturePercent * numel(order));
+            if isfield(hp,'fisherFeaturePercent')
+                numF = ceil(hp.fisherFeaturePercent * numel(order));
+            elseif isfield(hp,'numFisherFeatures')
+                numF = hp.numFisherFeatures;
+            else
+                numF = numel(order);
+            end
             numF = max(1, min(numF, numel(order)));
             selectedIdx = order(1:numF);
             Xp = Xp(:,selectedIdx);


### PR DESCRIPTION
## Summary
- add backwards compatibility for `numFisherFeatures` in `perform_inner_cv`
- support legacy field when training final models

## Testing
- `matlab -batch "disp('test')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843eb8f612883338337fdd3d360cc20