### PR TITLE
Remove p-value calculations from Phase 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Models are stored in `models/Phase3` and metrics in `results/Phase3`.
 
 ### Phase 4 – Feature interpretation
 
-Interpret the trained model by plotting LDA coefficients for the selected wavenumbers.
+Interpret the trained model by plotting LDA coefficients for the selected wavenumbers and generating mean spectra visualisations. Statistical p-value calculations were removed to streamline the phase.
 
 ```matlab
 run('src/run_phase4_feature_interpretation.m')


### PR DESCRIPTION
## Summary
- drop p-value logic from `run_phase4_feature_interpretation.m`
- load training data only for plotting
- save feature importance table without statistical columns
- clarify updated Phase 4 behaviour in the README

## Testing
- `octave --eval "disp('hello')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b2c0794708333858e66eaadb0c47f