### PR TITLE
Remove outlier strategy prompt in main script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This repository contains MATLAB code for analysing Fourier-transform infrared (F
 - `plotting/` – scripts for generating project figures.
 - `archive/` – older scripts retained for reference.
 - Top-level scripts such as `run_phase2_model_selection_comparative.m`, `run_phase3_final_evaluation.m` and `run_phase4_feature_interpretation.m` implement the main phases of the analysis.
+- A convenience wrapper `main.m` executes Phases 2–4 sequentially using the
+  recommended `AND` outlier strategy.  Edit `cfg.outlierStrategy` inside the
+  script if you need a different choice.
 
 The project expects the following folders in the repository root when running the scripts:
 

--- a/main.m
+++ b/main.m
@@ -8,15 +8,9 @@
 
 cfg = configure_cfg();
 
-disp('Select outlier removal strategy for evaluation:');
-disp(' 1 - AND (consensus, recommended)');
-disp(' 2 - OR  (lenient)');
-usr = input('Enter choice [1]: ','s');
-if isempty(usr) || str2double(usr)==1
-    cfg.outlierStrategy = 'AND';
-else
-    cfg.outlierStrategy = 'OR';
-end
+% Use the recommended AND strategy by default.  Edit `cfg.outlierStrategy`
+% manually if a different behaviour is desired.
+cfg.outlierStrategy = 'AND';
 
 % Ensure Phase 2 compares only the selected strategy
 cfg.outlierStrategiesToCompare = {cfg.outlierStrategy};


### PR DESCRIPTION
## Summary
- default `main.m` to the recommended AND strategy
- document the new default behaviour in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b95a73c408333b6583de4e2782e62