### PR TITLE
Centralize model application helper

### DIFF
--- a/helper_functions/apply_model_to_data.m
+++ b/helper_functions/apply_model_to_data.m
@@ -1,0 +1,35 @@
+function [yPred,scores] = apply_model_to_data(model,X,wn)
+%APPLY_MODEL_TO_DATA Preprocess and apply an LDA model to spectra.
+%   [yPred,scores] = APPLY_MODEL_TO_DATA(model,X,wn) bins the spectra if
+%   required, performs the configured feature selection transformation and
+%   then calls PREDICT on the trained LDA model.
+%
+% Inputs:
+%   model - struct containing fields:
+%       binningFactor           - scalar binning factor (optional)
+%       featureSelectionMethod  - 'pca' or other supported method
+%       selectedFeatureIndices  - indices for non-PCA feature selection
+%       PCACoeff, PCAMu         - PCA transformation matrices (when using PCA)
+%       LDAModel                - trained classification model with PREDICT
+%   X     - matrix of spectra (observations x features)
+%   wn    - row vector of wavenumbers corresponding to columns of X
+%
+% Outputs:
+%   yPred - predicted class labels
+%   scores - classification scores from the model
+%
+% This helper consolidates the shared logic used in Phase 2 and Phase 3
+% scripts for applying trained models to new data.
+
+    Xp = X; currentWn = wn; %#ok<NASGU>
+    if isfield(model,'binningFactor') && model.binningFactor>1
+        [Xp,currentWn] = bin_spectra(X,wn,model.binningFactor);
+    end
+    switch lower(model.featureSelectionMethod)
+        case 'pca'
+            Xp = (Xp - model.PCAMu) * model.PCACoeff;
+        otherwise
+            Xp = Xp(:,model.selectedFeatureIndices);
+    end
+    [yPred,scores] = predict(model.LDAModel,Xp);
+end

--- a/run_phase2_model_selection.m
+++ b/run_phase2_model_selection.m
@@ -123,20 +123,6 @@ save(resultsFile,'resultsPerPipeline','pipelines','metricNames','numOuterFolds',
 fprintf('Phase 2 results saved to %s\n',resultsFile);
 end
 
-function [yPred,scores] = apply_model_to_data(model,X,wn)
-    Xp = X; currentWn = wn;
-    if isfield(model,'binningFactor') && model.binningFactor>1
-        [Xp,currentWn] = bin_spectra(X,wn,model.binningFactor);
-    end
-    switch lower(model.featureSelectionMethod)
-        case 'pca'
-            Xp = (Xp - model.PCAMu) * model.PCACoeff;
-        otherwise
-            Xp = Xp(:,model.selectedFeatureIndices);
-    end
-    [yPred,scores] = predict(model.LDAModel,Xp);
-end
-
 function fieldName = find_field_by_prefix(S,prefix)
     fieldName = '';
     fns = fieldnames(S);

--- a/run_phase3_final_evaluation.m
+++ b/run_phase3_final_evaluation.m
@@ -130,20 +130,6 @@ fprintf('Saved Phase 3 comparison results to %s\n',resultsFile);
 end
 
 %% Helper functions
-function [yPred,scores] = apply_model_to_data(model,X,wn)
-    Xp = X; currentWn = wn;
-    if isfield(model,'binningFactor') && model.binningFactor>1
-        [Xp,currentWn] = bin_spectra(X,wn,model.binningFactor);
-    end
-    switch lower(model.featureSelectionMethod)
-        case 'pca'
-            Xp = (Xp - model.PCAMu) * model.PCACoeff;
-        otherwise
-            Xp = Xp(:,model.selectedFeatureIndices);
-    end
-    [yPred,scores] = predict(model.LDAModel,Xp);
-end
-
 function [tbl,metrics] = aggregate_probe_metrics(probeIDs,yTrue,scores,yPred,metricNames)
     probes = unique(probeIDs,'stable');
     tbl = table();


### PR DESCRIPTION
## Summary
- Add reusable `apply_model_to_data` helper consolidating shared model application logic
- Update Phase 2 and Phase 3 evaluation scripts to call helper after `setup_project_paths`
- Remove duplicate local `apply_model_to_data` implementations from scripts

## Testing
- `matlab -batch "disp('test')"` *(fails: command not found)*
- `octave --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb444392488333822a6dda05367230