### PR TITLE
Add fold metrics and confusion matrix options to visualization menu

### DIFF
--- a/plotting/run_visualization_menu.m
+++ b/plotting/run_visualization_menu.m
@@ -14,7 +14,8 @@ function run_visualization_menu()
         fprintf(' 2 - Exploratory outlier visualizations\n');
         fprintf(' 3 - Binning effect plot\n');
         fprintf(' 4 - Project summary (Phases 2-4)\n');
-        fprintf(' 5 - Confusion matrix (Phases 2 & 3)\n');
+        fprintf(' 5 - Phase 2 fold metrics\n');
+        fprintf(' 6 - Confusion matrix (Phases 2 & 3)\n');
         fprintf(' 0 - Exit\n');
         usr = input('Enter choice: ','s');
         if isempty(usr), choice = 0; else choice = str2double(usr); end
@@ -28,6 +29,8 @@ function run_visualization_menu()
             case 4
                 visualize_project_summary(cfg, opts);
             case 5
+                visualize_fold_metrics(cfg, opts);
+            case 6
                 visualize_confusion_matrix(cfg, opts);
             otherwise
                 if choice ~= 0


### PR DESCRIPTION
## Summary
- Extend visualization menu with Phase 2 fold metrics option and renumber existing confusion matrix entry
- Ensure switch-case dispatch aligns with new numbering

## Testing
- `matlab -batch "help run_visualization_menu"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4f98e3c08333ad23c5db0293ba07