### PR TITLE
Add spectral heatmap visualization

### DIFF
--- a/plotting/visualize_spectral_heatmap.m
+++ b/plotting/visualize_spectral_heatmap.m
@@ -55,8 +55,7 @@ function visualize_spectral_heatmap(P, opts)
         error('No class label column found in data_all_positions.');
     end
     class_labels = data_all_positions.(classField);
-    if iscategorical(class_labels), class_labels = cellstr(class_labels); end
-    if isstring(class_labels), class_labels = cellstr(class_labels); end
+    class_labels = cellstr(string(class_labels));
 
     unique_classes = unique(class_labels);
     numClasses = numel(unique_classes);


### PR DESCRIPTION
## Summary
- convert class labels to strings so numeric labels don't break spectral heatmap generation

## Testing
- `matlab -batch "help visualize_spectral_heatmap"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb531f2a7c8333974ca8e8dc87853a