### PR TITLE
Address path duplication when locating Phase 2 results

### DIFF
--- a/plotting/visualize_fold_metrics.m
+++ b/plotting/visualize_fold_metrics.m
@@ -15,7 +15,14 @@ function visualize_fold_metrics(P, opts)
         opts = plot_settings();
     end
 
-    phase2ResultsDir = fullfile(P.resultsPath, 'Phase2');
+    % Determine the Phase 2 results directory. If P.resultsPath already
+    % points to a Phase2 subdirectory, use it directly; otherwise append it.
+    phase2ResultsDir = P.resultsPath;
+    resultsPathClean = regexprep(P.resultsPath, [filesep '+$'], '');
+    if ~endsWith(resultsPathClean, 'Phase2')
+        phase2ResultsDir = fullfile(P.resultsPath, 'Phase2');
+    end
+
     files = dir(fullfile(phase2ResultsDir, '*_Phase2_AllPipelineResults.mat'));
     if isempty(files)
         error('No Phase 2 results file found in %s.', phase2ResultsDir);


### PR DESCRIPTION
## Summary
- avoid appending a second `Phase2` directory when `P.resultsPath` already points there

## Testing
- `octave --eval "addpath('helper_functions'); addpath('plotting'); visualize_fold_metrics(struct('resultsPath','/tmp'), struct());"` *(fails: No Phase 2 results file found in /tmp/Phase2.)*
- `octave --eval "addpath('helper_functions'); addpath('plotting'); visualize_fold_metrics(struct('resultsPath','/tmp/Phase2'), struct());"` *(fails: No Phase 2 results file found in /tmp/Phase2.)*

------
https://chatgpt.com/codex/tasks/task_e_68bb573a08f083338cf311a73900c4a1