### PR TITLE
Add helpers for final model training and hyperparameter aggregation

### DIFF
--- a/helper_functions/aggregate_best_hyperparams.m
+++ b/helper_functions/aggregate_best_hyperparams.m
@@ -1,0 +1,54 @@
+function agg = aggregate_best_hyperparams(hyperStructs)
+%AGGREGATE_BEST_HYPERPARAMS Combine hyperparameter selections across folds.
+%   AGG = AGGREGATE_BEST_HYPERPARAMS(HC) takes a cell array HC where each
+%   element is a struct of hyperparameters chosen on an inner fold. The
+%   function returns a struct AGG in which each field value is the mode of
+%   the corresponding values across folds (ignoring missing entries).
+%
+%   This helper provides a simple way to derive a single set of
+%   hyperparameters from the per‑fold selections produced during nested
+%   cross‑validation.
+%
+%   Date: 2025-06-16
+
+    agg = struct();
+    if isempty(hyperStructs)
+        return;
+    end
+
+    % Collect all field names appearing in the structs
+    allFields = {};
+    for i = 1:numel(hyperStructs)
+        if ~isempty(hyperStructs{i})
+            allFields = union(allFields, fieldnames(hyperStructs{i}));
+        end
+    end
+
+    for f = 1:numel(allFields)
+        fld = allFields{f};
+        vals = [];
+        for i = 1:numel(hyperStructs)
+            hs = hyperStructs{i};
+            if isstruct(hs) && isfield(hs, fld)
+                vals = [vals, hs.(fld)]; %#ok<AGROW>
+            end
+        end
+        if isempty(vals)
+            continue;
+        end
+        if isnumeric(vals)
+            aggVal = mode(vals);
+        else
+            % Convert to string for mode calculation
+            strVals = string(vals);
+            [u,~,ic] = unique(strVals);
+            counts = accumarray(ic,1);
+            [~,idx] = max(counts);
+            aggVal = u(idx);
+            if ischar(vals{1})
+                aggVal = char(aggVal);
+            end
+        end
+        agg.(fld) = aggVal;
+    end
+end

--- a/helper_functions/train_final_pipeline_model.m
+++ b/helper_functions/train_final_pipeline_model.m
@@ -1,0 +1,139 @@
+function [model, selectedIdx, selectedWn] = train_final_pipeline_model(X, y, wavenumbers, pipelineConfig, hyperparams)
+%TRAIN_FINAL_PIPELINE_MODEL Train a final model for a given pipeline.
+%   [MODEL, IDX, WN] = TRAIN_FINAL_PIPELINE_MODEL(X, Y, WN, PIPE, HYPER)
+%   bins the spectra if required, performs feature selection according to the
+%   pipeline specification and trains the configured classifier. The helper
+%   returns the model struct along with the indices of selected features and
+%   their corresponding wavenumbers.
+%
+%   Inputs
+%       X              - training spectra (observations x features)
+%       y              - class labels
+%       wavenumbers    - row vector of wavenumbers
+%       pipelineConfig - struct describing the pipeline
+%       hyperparams    - struct of chosen hyperparameter values
+%
+%   Outputs
+%       model      - struct containing fields used by APPLY_MODEL_TO_DATA
+%       selectedIdx- indices of selected features after preprocessing
+%       selectedWn - wavenumbers corresponding to selectedIdx
+%
+%   Date: 2025-06-16
+%
+%   This helper consolidates duplicated logic that was previously embedded
+%   in the Phase 2 script. It mirrors the preprocessing steps used during
+%   cross‑validation so the final model can be applied consistently later on.
+
+    % Default outputs
+    model = struct();
+    selectedIdx = [];
+    selectedWn = [];
+
+    % Ensure wavenumbers row vector
+    if iscolumn(wavenumbers)
+        wavenumbers = wavenumbers';
+    end
+
+    Xp = X; currentWn = wavenumbers;
+
+    % --- Binning ---
+    model.binningFactor = 1;
+    if isfield(hyperparams, 'binningFactor') && hyperparams.binningFactor > 1
+        [Xp, currentWn] = bin_spectra(X, wavenumbers, hyperparams.binningFactor);
+        model.binningFactor = hyperparams.binningFactor;
+    end
+
+    % --- Feature selection ---
+    model.featureSelectionMethod = pipelineConfig.feature_selection_method;
+    switch lower(pipelineConfig.feature_selection_method)
+        case 'fisher'
+            if isfield(hyperparams, 'fisherFeaturePercent')
+                numFeat = ceil(hyperparams.fisherFeaturePercent * size(Xp,2));
+            else
+                numFeat = size(Xp,2);
+            end
+            numFeat = min(numFeat, size(Xp,2));
+            if numFeat > 0 && size(Xp,1) > 1 && length(unique(y)) == 2
+                fr = calculate_fisher_ratio(Xp, y);
+                [~, sortIdx] = sort(fr, 'descend', 'MissingPlacement','last');
+                selectedIdx = sortIdx(1:numFeat);
+            else
+                selectedIdx = 1:size(Xp,2);
+            end
+            Xfs = Xp(:, selectedIdx);
+            selectedWn = currentWn(selectedIdx);
+            model.selectedFeatureIndices = selectedIdx;
+
+        case 'pca'
+            Xfs = Xp;
+            model.PCACoeff = [];
+            model.PCAMu = [];
+            if size(Xp,2) > 0 && size(Xp,1) > 1 && size(Xp,1) > size(Xp,2)
+                try
+                    [coeff, score, ~, ~, explained, mu] = pca(Xp);
+                    if isfield(hyperparams, 'pcaVarianceToExplain')
+                        cumExp = cumsum(explained);
+                        nComp = find(cumExp >= hyperparams.pcaVarianceToExplain*100, 1, 'first');
+                        if isempty(nComp); nComp = size(coeff,2); end
+                    elseif isfield(hyperparams,'numPCAComponents')
+                        nComp = min(hyperparams.numPCAComponents, size(coeff,2));
+                    else
+                        nComp = size(coeff,2);
+                    end
+                    coeff = coeff(:,1:nComp); score = score(:,1:nComp);
+                    model.PCACoeff = coeff;
+                    model.PCAMu = mu;
+                    Xfs = score;
+                    selectedIdx = 1:nComp;
+                catch
+                    % fallback to using original features
+                    selectedIdx = 1:size(Xp,2);
+                    Xfs = Xp;
+                end
+            else
+                selectedIdx = 1:size(Xp,2);
+            end
+            selectedWn = [];
+            model.selectedFeatureIndices = selectedIdx; % not used but keep for completeness
+
+        case 'mrmr'
+            if isfield(hyperparams, 'mrmrFeaturePercent')
+                numFeat = ceil(hyperparams.mrmrFeaturePercent * size(Xp,2));
+            else
+                numFeat = size(Xp,2);
+            end
+            numFeat = min(numFeat, size(Xp,2));
+            if numFeat>0 && size(Xp,1)>1 && length(unique(y))==2 && exist('fscmrmr','file')
+                try
+                    ycat = categorical(y);
+                    [idx,~] = fscmrmr(Xp, ycat);
+                    numFeat = min(numFeat, length(idx));
+                    selectedIdx = idx(1:numFeat);
+                catch
+                    selectedIdx = 1:size(Xp,2);
+                end
+            else
+                selectedIdx = 1:size(Xp,2);
+            end
+            Xfs = Xp(:,selectedIdx);
+            selectedWn = currentWn(selectedIdx);
+            model.selectedFeatureIndices = selectedIdx;
+
+        otherwise
+            selectedIdx = 1:size(Xp,2);
+            Xfs = Xp;
+            selectedWn = currentWn(selectedIdx);
+            model.selectedFeatureIndices = selectedIdx;
+    end
+
+    % --- Train classifier ---
+    switch lower(pipelineConfig.classifier)
+        case 'lda'
+            mdl = fitcdiscr(Xfs, y);
+        otherwise
+            error('Unsupported classifier: %s', pipelineConfig.classifier);
+    end
+
+    model.LDAModel = mdl;
+    model.pipelineName = pipelineConfig.name;
+end

--- a/run_phase2_model_selection.m
+++ b/run_phase2_model_selection.m
@@ -9,6 +9,7 @@ fprintf('PHASE 2: Model Selection - %s\n', string(datetime('now')));
 if nargin < 1, cfg = struct(); end
 if ~isfield(cfg,'projectRoot'); cfg.projectRoot = pwd; end
 
+% Add helper_functions/ to the path and obtain common directories
 P = setup_project_paths(cfg.projectRoot,'Phase2');
 dataPath = P.dataPath;
 resultsPath = P.resultsPath;


### PR DESCRIPTION
## Summary
- implement `train_final_pipeline_model` helper to bin spectra, perform feature selection, and train LDA models while returning selected feature indices and wavenumbers
- add `aggregate_best_hyperparams` helper to collapse inner-fold hyperparameter selections using the most frequent value
- clarify Phase 2 model selection script to rely on these helpers via `setup_project_paths`

## Testing
- `octave --version` *(fails: command not found)*
- `matlab -batch "exit"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5be8ece4833388f0bd23ccd2ca0d